### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/WeaverLilyMae/0e602bd1-a705-4053-87f9-04ecae4daeba/d1ece446-0561-4569-8ab9-02fcf021f53c/_apis/work/boardbadge/9ca820a6-bc99-40e6-a915-1e821830e8cc)](https://dev.azure.com/WeaverLilyMae/0e602bd1-a705-4053-87f9-04ecae4daeba/_boards/board/t/d1ece446-0561-4569-8ab9-02fcf021f53c/Microsoft.RequirementCategory)
 # courtlistener-solr-server
 Scripts and configurations for making Solr work in CourtListener


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/WeaverLilyMae/0e602bd1-a705-4053-87f9-04ecae4daeba/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.